### PR TITLE
Initialize actuators

### DIFF
--- a/gazebo_naoqi_control/src/gazebo_naoqi_control_plugin.cpp
+++ b/gazebo_naoqi_control/src/gazebo_naoqi_control_plugin.cpp
@@ -205,6 +205,19 @@ void GazeboNaoqiControlPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _
     }
   }
 
+  // Initialize actuators
+  for(std::vector<const Sim::AngleActuator*>::const_iterator it =
+      angle_actuators_.begin(); it != angle_actuators_.end(); ++it)
+  {
+    float actuatorPosition = naoqi_hal_->fetchAngleActuatorValue(*it);
+    if(actuatorPosition != actuatorPosition)
+    {
+      actuatorPosition = (*it)->startValue();
+    }
+    const Sim::AngleSensor* sensor = naoqi_model_->angleSensor((*it)->name());
+    naoqi_hal_->sendAngleSensorValue(sensor, actuatorPosition);
+  }
+
   // Initialize Sensors
   initSensors();
 


### PR DESCRIPTION
NAOqi produced an error when starting the walk because some data was not initialized.
This commit should fix that issue.

Note that I have initially tested it based on c82b1f2cb652e3f85fca1f76cd06c516c5f65d39, and I could see Nao take 2 or 3 steps before falling forward.
With the latest commits the steps are less smooth. It might be related to the change restoring collisions? (62a460f12f2b3627c39b8badec4d18c39f6bde09)
